### PR TITLE
.gitsubmodules: Point to coreboot goswid repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -63,5 +63,5 @@
 	branch = stmpe
 [submodule "util/goswid"]
 	path = util/goswid
-	url = ../goswid
+	url = https://github.com/coreboot/goswid
 	branch = trunk


### PR DESCRIPTION
Signed-off-by: Christian Walter <christian.walter@9elements.com>